### PR TITLE
feat: 회원 가입 API 구현

### DIFF
--- a/api-test/member-api.http
+++ b/api-test/member-api.http
@@ -1,0 +1,9 @@
+POST localhost:8080/api/members/signup
+Content-Type: application/json
+
+{
+  "email": "hong-gd@gmail.com",
+  "password": "password",
+  "name": "홍길동",
+  "nickname": "동에번쩍 서에번쩍"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -18,16 +18,19 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    compileOnly 'org.projectlombok:lombok:1.18.32'
-    annotationProcessor 'org.project:lombok:1.18.32'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/assistant/common/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/example/assistant/common/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.example.assistant.common.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+}

--- a/src/main/java/com/example/assistant/common/security/SecurityConfig.java
+++ b/src/main/java/com/example/assistant/common/security/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.example.assistant.common.security;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.*;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/api/members/signup").permitAll()
+				.requestMatchers("/api/members/signin").permitAll()
+				.requestMatchers("/api/riot").permitAll()
+				.anyRequest().authenticated()
+			)
+
+			.build();
+	}
+
+}

--- a/src/main/java/com/example/assistant/domain/member/Member.java
+++ b/src/main/java/com/example/assistant/domain/member/Member.java
@@ -1,0 +1,37 @@
+package com.example.assistant.domain.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String email;
+
+	@Column(nullable = false)
+	private String password;
+
+	@Column(nullable = false)
+	private String name;
+
+	private String nickname;
+
+	public Member(String email, String password, String name, String nickname) {
+		this.email = email;
+		this.password = password;
+		this.name = name;
+		this.nickname = nickname;
+	}
+}

--- a/src/main/java/com/example/assistant/domain/member/Member.java
+++ b/src/main/java/com/example/assistant/domain/member/Member.java
@@ -5,12 +5,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@Table(name = "members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 	@Id

--- a/src/main/java/com/example/assistant/domain/member/MemberController.java
+++ b/src/main/java/com/example/assistant/domain/member/MemberController.java
@@ -1,0 +1,40 @@
+package com.example.assistant.domain.member;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+	private final MemberService memberService;
+
+	/**
+	 * 회원 가입 요청 정보를 수신하고 그 결과를 반환
+	 * POST http://localhost:8080/api/members/singup
+	 *
+	 * Contents-type: application/json
+	 *
+	 * {
+	 *     "email" : "hong-gd@gmail.com",
+	 *     "password" : "password",
+	 *     "name" : "홍길동",
+	 *     "nickname" : "동에번쩍 서에번쩍"
+	 * }
+	 */
+	@PostMapping("/signup")
+	ResponseEntity<Void> signup(@RequestBody SignupRequest signupRequest) {
+		memberService.signup(
+			signupRequest.getEmail(),
+			signupRequest.getPassword(),
+			signupRequest.getName(),
+			signupRequest.getNickname()
+		);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/example/assistant/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/assistant/domain/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.example.assistant.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+	boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/assistant/domain/member/MemberService.java
+++ b/src/main/java/com/example/assistant/domain/member/MemberService.java
@@ -1,0 +1,33 @@
+package com.example.assistant.domain.member;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	/**
+	 * 회원 가입
+	 * - 이미 회원 가입된 이메일인 경우?
+	 * - 비밀번호는 암호화 되어야 할 것 같은데
+	 */
+	public void signup(String email, String password, String name, String nickname) {
+		// 이메일 중복검사
+		boolean isExist = memberRepository.existsByEmail(email);
+		if (isExist) {
+			throw new RuntimeException("이미 존재 하는 이메일입니다.");
+		}
+
+		// 비밀번호 암호화
+		String encodedPassword = passwordEncoder.encode(password);
+		Member member = new Member(email, encodedPassword, name, nickname);
+
+		// DB 저장
+		memberRepository.save(member);
+	}
+}

--- a/src/main/java/com/example/assistant/domain/member/SignupRequest.java
+++ b/src/main/java/com/example/assistant/domain/member/SignupRequest.java
@@ -1,0 +1,11 @@
+package com.example.assistant.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public class SignupRequest {
+	private String email;
+	private String password;
+	private String name;
+	private String nickname;
+}

--- a/src/main/java/com/example/assistant/domain/riot/Enum/GameResult.java
+++ b/src/main/java/com/example/assistant/domain/riot/Enum/GameResult.java
@@ -4,17 +4,14 @@ import lombok.Getter;
 
 @Getter
 public enum GameResult {
-    WIN("승리"),  // 승리
-    LOSE("패배");
+	WIN("승리"),  // 승리
+	LOSE("패배");
 
-    private final String description;
+	private final String description;
 
-    GameResult(String description) {
-
-
-    }
-
-
+	GameResult(String description) {
+		this.description = description;
+	}
 }
 
 

--- a/src/main/java/com/example/assistant/domain/riot/repository/MatchRepository.java
+++ b/src/main/java/com/example/assistant/domain/riot/repository/MatchRepository.java
@@ -1,14 +1,10 @@
 package com.example.assistant.domain.riot.repository;
 
-import com.example.assistant.domain.riot.entity.Match;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
+import com.example.assistant.domain.riot.entity.Match;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
-    @Query
-    List<Match> findTopBy20ByRiotIdAndTagline(@Param("riotId") String riotId, @Param("tagline") String tagline, Pageable pageable);
+	// List<Match> findTopBy20ByRiotIdAndTagline(@Param("riotId") String riotId, @Param("tagline") String tagline,
+	// 	Pageable pageable);
 }

--- a/src/main/java/com/example/assistant/domain/riot/service/MatchService.java
+++ b/src/main/java/com/example/assistant/domain/riot/service/MatchService.java
@@ -1,35 +1,35 @@
 package com.example.assistant.domain.riot.service;
 
-import com.example.assistant.domain.riot.dto.response.MatchResponse;
-import com.example.assistant.domain.riot.entity.Match;
-import com.example.assistant.domain.riot.repository.MatchRepository;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import com.example.assistant.domain.riot.dto.response.MatchResponse;
+import com.example.assistant.domain.riot.repository.MatchRepository;
 
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MatchService {
-    private final MatchRepository matchRepository;
+	private final MatchRepository matchRepository;
 
-    public List<MatchResponse> getRecentMatches(String riotId, String tagline) {
-        Pageable pageable = PageRequest.of(0,20);
-        List<Match> matches = matchRepository.findTopBy20ByRiotIdAndTagline(riotId, tagline, pageable);
-
-        return matches.stream()
-                .map(match -> MatchResponse.builder()
-                        .matchId(match.getMatchId())
-                        .championName(match.getChamptionName())
-                        .kda(match.getKda())
-                        .result(match.getResult())
-                        .playDate(match.getPlayDate())
-                        .duration(match.getDuration())
-                        .build())
-                .collect(Collectors.toList());
-    }
+	public List<MatchResponse> getRecentMatches(String riotId, String tagline) {
+		Pageable pageable = PageRequest.of(0, 20);
+		// List<Match> matches = matchRepository.findTopBy20ByRiotIdAndTagline(riotId, tagline, pageable);
+		//
+		// return matches.stream()
+		//         .map(match -> MatchResponse.builder()
+		//                 .matchId(match.getMatchId())
+		//                 .championName(match.getChamptionName())
+		//                 .kda(match.getKda())
+		//                 .result(match.getResult())
+		//                 .playDate(match.getPlayDate())
+		//                 .duration(match.getDuration())
+		//                 .build())
+		//         .collect(Collectors.toList());
+		return null;
+	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,7 @@
 spring.application.name=assistant
 riot.api.key=
 spring.ai.openai.api-key=
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.highlight_sql=true

--- a/src/test/java/com/example/assistant/domain/member/MemberRepositoryTest.java
+++ b/src/test/java/com/example/assistant/domain/member/MemberRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.example.assistant.domain.member;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DisplayName("Repository:Member")
+@DataJpaTest
+class MemberRepositoryTest {
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("회원 저장")
+	void save() {
+		// Given
+		Member member = new Member("hong-gd@gmail.com", "password", "홍길동", "동에번쩍 서에번쩍");
+
+		// When
+		memberRepository.save(member);
+
+		// Then
+		System.out.println(member.getId());
+	}
+
+}

--- a/src/test/java/com/example/assistant/domain/member/MemberTest.java
+++ b/src/test/java/com/example/assistant/domain/member/MemberTest.java
@@ -1,0 +1,22 @@
+package com.example.assistant.domain.member;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Entity:Member")
+class MemberTest {
+	@Test
+	@DisplayName("Member Entity 객체 생성")
+	void create() {
+		// When
+		Member member = new Member("hong-gd@gmail.com", "password", "홍길동", "동에번쩍 서에번쩍");
+
+		// Then
+		System.out.println(member.getId());
+		System.out.println(member.getEmail());
+		System.out.println(member.getPassword());
+		System.out.println(member.getName());
+		System.out.println(member.getNickname());
+	}
+
+}


### PR DESCRIPTION
- 회원 테이블과 매핑할 Member Jpa Entity 정의
- Member Jpa Entity를 회원 테이블과 연동해줄 MemberJpaRepository 구성
- 회원 가입 비지니스 로직을 처리할 MemberService 구현
- 회원 가입 요청을 수신하고 그 처리 결과를 응답으로 반환 하는 MemberController 구현
- 회원 가입 API의 동작을 확인하기 위한 script 구성